### PR TITLE
Add keyword arguments support for db connection

### DIFF
--- a/easydb/__init__.py
+++ b/easydb/__init__.py
@@ -7,7 +7,7 @@ class EasyDB:
         if not exists and not schema:
             raise Exception, "The specified database file does not exist, and you haven't provided a schema"
     
-        self.connection = sqlite3.connect(filename)
+        self.connection = sqlite3.connect(filename, **kwargs)
         if not exists:
             for table_name, fields in schema.items():
                 query = "CREATE TABLE %s (%s)" % (table_name, ", ".join(fields))


### PR DESCRIPTION
In order to use features such as `check_same_thread=False` etc. it is highly advisable to include the `**kwargs` from the `__init__(..., **kwargs)` function in the `sqlite3.connect()` function.
